### PR TITLE
Add basic CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,27 @@ jobs:
         with:
           name: regdesc-build
           path: dist/
+  test:
+    name: Test
+    needs: lint-build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: regdesc-build
+          path: dist/
+      - name: Install test runner
+        run: |
+          pip install pytest
+      - name: Install source package
+        run: |
+          pip install dist/regdesc-*.tar.gz
+      - name: Test
+        run: |
+          pytest --pyargs regdesc.tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Test and build
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    name: Test and build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eifinger/setup-rye@v3
+      - name: Install dependencies
+        run: |
+          rye sync
+      - name: Spellcheck
+        run: |
+          rye run typos .
+      - name: Check format
+        run: |
+          rye fmt --check
+          rye run pyproject-fmt --check .
+      - name: Lint
+        run: |
+          rye lint
+      - name: Build
+        run: |
+          rye build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
-name: Test and build
+name: Lint, Build, Test
 on:
   pull_request:
   push:
     branches:
       - master
 jobs:
-  test:
-    name: Test and build
+  lint-build:
+    name: Lint and build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,3 +27,7 @@ jobs:
       - name: Build
         run: |
           rye build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: regdesc-build
+          path: dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,6 @@ dev-dependencies = [
   "pyproject-fmt>=1.7.0",
   "ruff>=0.3.3",
   "typos>=1.22.8",
+  "pytest>=8.2.2",
+  "pytest-sugar>=1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[build-system]
+build-backend = "hatchling.build"
+requires = [
+  "hatchling",
+]
+
 [project]
 name = "regdesc"
 version = "0.1.0"
@@ -5,9 +11,9 @@ description = "Pythonic hardware register descriptors."
 readme = "README.md"
 license = "GPL-3.0"
 authors = [
-    { name = "Etienne Wodey", email = "airwoodix@posteo.me" }
+  { name = "Etienne Wodey", email = "airwoodix@posteo.me" },
 ]
-requires-python = ">= 3.8"
+requires-python = ">=3.8"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.8",
@@ -19,34 +25,29 @@ classifiers = [
 dependencies = [
   "jinja2>=1",
 ]
-[project.scripts]
-regdesc-codegen = "regdesc.codegen.template:ep_codegen"
-regdesc-gen-rs-pac = "regdesc.codegen.rust_dummy_pac:ep_rust_dummy_pac"
-regdesc-serialize = "regdesc.codegen.ir:ep_emit_json"
-
-[build-system]
-build-backend = "hatchling.build"
-requires = [
-  "hatchling",
-]
+scripts.regdesc-codegen = "regdesc.codegen.template:ep_codegen"
+scripts.regdesc-gen-rs-pac = "regdesc.codegen.rust_dummy_pac:ep_rust_dummy_pac"
+scripts.regdesc-serialize = "regdesc.codegen.ir:ep_emit_json"
 
 [tool.hatch.metadata]
 allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
-packages = ["regdesc"]
+packages = [
+  "regdesc",
+]
 
 [tool.ruff]
+target-version = "py38"
 line-length = 100
-target-version = 'py38'
 extend-exclude = [
-  "*.tpl.py",  # Python template files, contains Jinja2 syntax.
+  "*.tpl.py", # Python template files, contains Jinja2 syntax.
 ]
 
 [tool.rye]
 managed = true
 dev-dependencies = [
-    "pyproject-fmt>=1.7.0",
-    "ruff>=0.3.3",
-    "typos>=1.22.8",
+  "pyproject-fmt>=1.7.0",
+  "ruff>=0.3.3",
+  "typos>=1.22.8",
 ]

--- a/regdesc/tests/test_register.py
+++ b/regdesc/tests/test_register.py
@@ -3,17 +3,22 @@ from regdesc import Field, Register
 
 
 class TestRegAddrInReg(Register):
+    __test__ = False  # prevent test collection
+
     address = Field(2, reset=2, readonly=True)
     f0 = Field(12, reset=12)
 
 
 class TestRegCBInReg(Register):
+    __test__ = False  # prevent test collection
+
     control_bits = Field(3, reset=5, readonly=True)
     f0 = Field(12, reset=12)
     f1 = Field(14, reset=1234)
 
 
 class TestReg(Register):
+    __test__ = False  # prevent test collection
     __address__ = 0xE
 
     f0 = Field(12, reset=12)


### PR DESCRIPTION
Add a basic CI setup with two jobs:

1. **Lint and Build**: checks format and linting rules, then builds the package (source and wheel)
2. **Test**: runs the tests against the built source package against the support Python versions.